### PR TITLE
Update vulnerable range for jws package

### DIFF
--- a/master/snapshot.json
+++ b/master/snapshot.json
@@ -2008,8 +2008,8 @@
 				"disclosureTime": "2016-07-26T17:21:17.000Z",
 				"description": "## Overview\nSince \"algorithm\" isn't enforced in `jws.verify()`, a malicious user could choose what algorithm is sent to the server. If the server is expecting RSA but is sent HMAC-SHA with RSA's public key, the server will think the public key is actually an HMAC private key. This could be used to forge any data an attacker wants.\n\nIn addition, there is the `none` algorithm to be concerned about.  In versions prior to 2.0.0, verification of the token could be bypassed when the `alg` field is set to `none`.\n\nSource: _Node Security Project_\n\n## Remediation\nUpdate to `jws` version `2.0.0` or later.\n\n## References\nhttps://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/\n\n",
 				"semver": {
-					"vulnerable": "<2.0.0",
-					"unaffected": ">=2.0.0"
+					"vulnerable": "<3.0.0",
+					"unaffected": ">=3.0.0"
 				},
 				"CVSSv3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:N",
 				"severity": "high",


### PR DESCRIPTION
- [x] ready for merge
- [ ] copy review by 
  - [ ] title
  - [ ] description
  - [ ] semver validity
  - [ ] creation/publication/modificatoin dates
- [ ] code/patch review by 
  - [ ] patch validity
  - [ ] semver validity
  - [ ] license
  - [ ] tests/fixtures

#### What's this PR do?

Improves vulnerable range for the jws package. I compared your database with nodesecurity.io and noticed that the range for jws is much wider in the nodesecurity db: https://api.nodesecurity.io/advisories. I know that the range in the NodeSecurity.IO DB was the same as here, but it was updated a couple days ago, that's why I assume it's more up-to-date then the entry here. 

##### What is the affected modules

jws

##### What vulnerabilities were added

none

##### Severity / CVSS

##### NPM Stats

##### Affected Users/Projects 

##### What patches where added

#### What are the relevant tickets

#### References

